### PR TITLE
Add starter template website

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Read more about Ephemeral Rollups [here](https://docs.magicblock.gg/EphemeralRol
 - [Rust Counter](./rust-counter/README.md) - A simple counter that can be incremented. Tests natively to delegate/undelegate accounts and run transactions.
 - [Bolt Counter](./bolt-counter/README.md) - A simple counter that can be incremented. Tests use the bolt sdk to delegate/undelegate accounts and run transactions.
 - [Dummy Token Transfer](./dummy-token-transfer/README.md) - A token transferer that can delegate and execute both on-chain and in the ephemeral rollup.
+- [Starter Template](./starter-template/README.md) - Minimal website with local wallet, network toggle and ping transaction.
 
 ## 🚧 Under Testing 🚧
 

--- a/starter-template/README.md
+++ b/starter-template/README.md
@@ -1,0 +1,8 @@
+# Starter Template Website
+
+This example shows a minimal web page for interacting with MagicBlock networks.
+It creates a local wallet in the browser and lets you airdrop funds on the
+selected network and send a no-op transaction using the **Ping** button.
+
+Open `index.html` in a browser to try it out. Use the network selector to switch
+between **Devnet** and the **Ephemeral Rollup**.

--- a/starter-template/index.html
+++ b/starter-template/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MagicBlock Starter</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        #wallet { margin-bottom: 10px; }
+        button { margin-right: 5px; }
+    </style>
+</head>
+<body>
+    <h1>MagicBlock Starter</h1>
+    <div>
+        Network:
+        <select id="network">
+            <option value="devnet">Devnet</option>
+            <option value="ephemeral">Ephemeral</option>
+        </select>
+    </div>
+    <p id="wallet">Loading wallet...</p>
+    <button id="airdrop">Airdrop 1 SOL</button>
+    <button id="ping">Ping</button>
+
+    <script type="module">
+        import {Connection, clusterApiUrl, Keypair, LAMPORTS_PER_SOL, SystemProgram, Transaction} from 'https://cdn.jsdelivr.net/npm/@solana/web3.js@1.98.0/+esm';
+
+        const NETWORKS = {
+            devnet: clusterApiUrl('devnet'),
+            ephemeral: 'https://devnet.magicblock.app/'
+        };
+
+        let secret = localStorage.getItem('secret');
+        let keypair;
+        if (secret) {
+            const secretKey = Uint8Array.from(JSON.parse(secret));
+            keypair = Keypair.fromSecretKey(secretKey);
+        } else {
+            keypair = Keypair.generate();
+            localStorage.setItem('secret', JSON.stringify(Array.from(keypair.secretKey)));
+        }
+
+        const walletElem = document.getElementById('wallet');
+        walletElem.textContent = `Wallet: ${keypair.publicKey.toBase58()}`;
+
+        async function getConnection() {
+            const net = document.getElementById('network').value;
+            return new Connection(NETWORKS[net], 'confirmed');
+        }
+
+        document.getElementById('airdrop').onclick = async () => {
+            const connection = await getConnection();
+            const sig = await connection.requestAirdrop(keypair.publicKey, LAMPORTS_PER_SOL);
+            await connection.confirmTransaction(sig, 'confirmed');
+            alert('Airdrop tx: ' + sig);
+        };
+
+        document.getElementById('ping').onclick = async () => {
+            const connection = await getConnection();
+            const tx = new Transaction().add(SystemProgram.transfer({
+                fromPubkey: keypair.publicKey,
+                toPubkey: keypair.publicKey,
+                lamports: 0
+            }));
+            tx.feePayer = keypair.publicKey;
+            tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+            tx.sign(keypair);
+            const sig = await connection.sendRawTransaction(tx.serialize());
+            await connection.confirmTransaction(sig, 'confirmed');
+            alert('Ping tx: ' + sig);
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new web example `starter-template`
- document starter example in root README

## Testing
- `npx --yes prettier@3.2.5 -v`

------
https://chatgpt.com/codex/tasks/task_e_68576e03b8948329aff997224d50772d